### PR TITLE
Delete compiled assets directory before building

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,8 +6,8 @@
   "scripts": {
     "build:assets": "webpack --config webpack.config.prod.js",
     "build:site": "ELEVENTY_ENV=production npx eleventy",
-    "del:dist": "rimraf ./dist",
     "del:assets": "rimraf ./src/compiled-assets",
+    "del:dist": "rimraf ./dist",
     "dev": "npm run dev:assets & npm run dev:site",
     "dev:assets": "webpack --config webpack.config.dev.js",
     "dev:site": "ELEVENTY_ENV=development npx eleventy --serve",

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
     "build:assets": "webpack --config webpack.config.prod.js",
     "build:site": "ELEVENTY_ENV=production npx eleventy",
     "del:dist": "rimraf ./dist",
+    "del:assets": "rimraf ./src/compiled-assets",
     "dev": "npm run dev:assets & npm run dev:site",
     "dev:assets": "webpack --config webpack.config.dev.js",
     "dev:site": "ELEVENTY_ENV=development npx eleventy --serve",
-    "prod": "npm-run-all del:dist build:assets build:site",
+    "prod": "npm-run-all del:dist del:assets build:assets build:site",
     "serve:prod": "serve ./dist/"
   },
   "repository": {


### PR DESCRIPTION
Deleting the src/compiled-assets directory allows us to account for the case when src/compiled-assets contains a file no longer needed (for instance, a file that Webpack used to build but no longer builds). If we do not delete it, Eleventy will copy it to the dist/assets directory (since it copies the entire compiled-assets directory to dist/assets), and our website will end up having an unnecessary file.